### PR TITLE
WIP: add in-toto

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
-
+in-toto~=0.4.0
+pynacl


### PR DESCRIPTION
Adds signing and attesting facilities with in-toto and enriches the attestation with RBVF-relevant fields. The resulting link looks like:
```
{
 "signatures": [
  {
   "keyid": "9407afd764b548bb7fcf4d963f26dd2b70e01b85b50bc8f4d067007c3f5cf819",
   "sig": "c1bec9b7c19e0e026577be4b31d74e933aeeb2b95824dd421ad7d856c114e5c66928c6593527e6e10ccdc7fd06c5c1e027be1cdc20b385575c89adeceb529e07"
  }
 ],
 "signed": {
  "_type": "link",
  "byproducts": {
     "BUILD_LOGS",
     "DIFFOSCOPE_OUTPUT_IF_REQUIRED"
   },
  "command": [],
  "environment": {
   "rbvf": {
    "origin_name": "openwrt",
    "origin_uri": "https://downloads.cdn.openwrt.org",
    "rebuilder": {
     "contact": "unknown",
     "maintainer": "unknown",
     "name": "unknown",
     "uri": "unknown"
    },
    "results": [
      $LOGS_URIS_ETC
    ]
   }
  },
  "materials": {
     $GIT_CHECKOUT_USED_IN_REBUILD_AND_THEIR_HASHES
   },
  "name": "rebuild",
  "products": {
     $IPK_FILES_AND_THEIR_HASHES
  }
 }
```

This is still a WIP, as we could move some elements (e.g., result logs to byproducts). Once enough attestations are produced by rebuilders, an in-toto verifier can attest for an artifact being reproduced (using in-toto-verify, coming soon™)